### PR TITLE
Improve get-position

### DIFF
--- a/src/get-position.js
+++ b/src/get-position.js
@@ -1,11 +1,11 @@
 const _ = require('lodash');
 
 function isRequire(line) {
-    return line.match(/require/) || line.match(/^import/);
+    return line.match(/require\(/) || line.match(/^import/);
 }
 
 function isCommentOrEmpty(line) {
-    return _.isEmpty(line) || line.match(/^\s*\/\//);
+    return _.isEmpty(line) || line.match(/^\s*\/\//) || line.match(/^\s*["']use strict["']/);
 }
 
 module.exports = function(codeBlock) {


### PR DESCRIPTION
Hi, thanks for this awesome extension!

I've come across a little problem where this extension places `require()` statements before use stricts. This PR is intended to fix:

- Keep use-strict at the beginning of the file
- Make isRequire() a little more specific

**Please:** This PR needs testing before merge because I've just edited it here on Github 😁 