### PR TITLE
Insert absolute imports before relative imports

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -10,10 +10,7 @@ const detectFileRequireMethod = require('./detectFileRequireMethod');
 const constants = require('./constants');
 const _ = require('lodash');
 const getPackageDeepFiles = require('./get-package-deep-files');
-
-function isRequire(line) {
-    return line.match(/require\(/) || line.match(/^import/);
-}
+const isRequire = require('./is-require');
 
 function activate(context) {
     const config = vscode.workspace.getConfiguration('bitk_node_require') || {};

--- a/src/extension.js
+++ b/src/extension.js
@@ -11,6 +11,10 @@ const constants = require('./constants');
 const _ = require('lodash');
 const getPackageDeepFiles = require('./get-package-deep-files');
 
+function isRequire(line) {
+    return line.match(/require\(/) || line.match(/^import/);
+}
+
 function activate(context) {
     const config = vscode.workspace.getConfiguration('bitk_node_require') || {};
     const includePattern = `**/*.{${config.include.toString()}}`;
@@ -77,9 +81,11 @@ function activate(context) {
 
                     let relativePath;
                     let importName;
+                    let isExternal;
 
                     if (value.fsPath) {
                         // A local file was selected
+                        isExternal = false;
                         if (editor.document.fileName === value.fsPath) {
                             vscode.window.showErrorMessage('You are trying to require this file.');
                             return;
@@ -116,13 +122,14 @@ function activate(context) {
                         }
                     } else {
                         // A core module or dependency was selected
+                        isExternal = true;
                         relativePath = value.label;
                         const commonName = commonNames(value.label, config.aliases);
                         importName = commonName || caseName(value.label);
                     }
 
                     const codeBlock = editor.document.getText().split(os.EOL);
-                    const lineStart = getPosition(editor.document.getText().split(os.EOL));
+                    const lineStart = getPosition(editor.document.getText().split(os.EOL), isExternal);
                     const cursorPosition = editor.selection.active;
 
                     Promise
@@ -151,7 +158,8 @@ function activate(context) {
                         .then((script) => {
                             editor.edit((editBuilder) => {
                                 const position = new vscode.Position(lineStart, 0);
-                                const insertText = !_.isEmpty(codeBlock[lineStart]) ? `${script}\n\n` : `${script}\n`;
+                                const existingLine = codeBlock[lineStart];
+                                const insertText = !_.isEmpty(existingLine) && !isRequire(existingLine) ? `${script}\n\n` : `${script}\n`;
                                 if (!codeBlock.some(line => line === script)) editBuilder.insert(position, insertText);
                                 if (insertAtCursor) editBuilder.insert(cursorPosition, importName);
                             });

--- a/src/get-position.js
+++ b/src/get-position.js
@@ -8,13 +8,21 @@ function isCommentOrEmpty(line) {
     return _.isEmpty(line) || line.match(/^\s*\/\//) || line.match(/^\s*["']use strict["']/);
 }
 
-module.exports = function(codeBlock) {
+function isLocalRequire(line) {
+    return line.match(/require\([\s]?['|"][.|/]/) || line.match(/^import.*from\s['|"][.|/]/);
+}
+
+module.exports = function(codeBlock, placeWithExternals) {
     let candidate = 0;
 
     for (let i = 0; i < codeBlock.length; i += 1) {
         const line = codeBlock[i];
 
-        if (isRequire(line)) {
+        if (isRequire(line) && (
+            !placeWithExternals ||
+            (placeWithExternals && !isLocalRequire(line))
+           )
+        ) {
             candidate = i + 1;
         } else if (!isCommentOrEmpty(line)) {
             break;

--- a/src/get-position.js
+++ b/src/get-position.js
@@ -1,8 +1,5 @@
 const _ = require('lodash');
-
-function isRequire(line) {
-    return line.match(/require\(/) || line.match(/^import/);
-}
+const isRequire = require('./is-require');
 
 function isCommentOrEmpty(line) {
     return _.isEmpty(line) || line.match(/^\s*\/\//) || line.match(/^\s*["']use strict["']/);
@@ -14,10 +11,8 @@ function isLocalRequire(line) {
 
 module.exports = function(codeBlock, placeWithExternals) {
     let candidate = 0;
-
     for (let i = 0; i < codeBlock.length; i += 1) {
         const line = codeBlock[i];
-
         if (isRequire(line) && (
             !placeWithExternals ||
             (placeWithExternals && !isLocalRequire(line))
@@ -28,6 +23,5 @@ module.exports = function(codeBlock, placeWithExternals) {
             break;
         }
     }
-
     return candidate;
 };

--- a/src/is-require.js
+++ b/src/is-require.js
@@ -1,0 +1,3 @@
+module.exports = function isRequire(line) {
+    return line.match(/require\(/) || line.match(/^import/);
+};


### PR DESCRIPTION
This should resolve issue #8.

It makes sure that absolute imports (core modules & external dependencies) are placed together, above local imports.

To accomplish this, it passes whether the import is external to `get-position`. In `get-position` we have a bit of new logic + a new function to test if a line in a code block is an external or local import (`isLocalRequire`).

I also had to add an `isRequire` test in `extension.js` to determine if an additional line-break should be added after the new import (since we don't want one when adding a new external import above an existing local import).

I wasn't sure if you'd prefer to duplicate that function or pull it into its own file for reuse.