### PR TITLE
Option for semicolons

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
           ],
           "description": "include files to search for"
         },
+        "bitk_node_require.use_semicolon": {
+          "type": "boolean",
+          "default": true,
+          "description": "Adds a semicolon at the end of the require statement"
+        },
         "bitk_node_require.exclude": {
           "type": "array",
           "default": [

--- a/src/extension.js
+++ b/src/extension.js
@@ -147,9 +147,13 @@ function activate(context) {
                             let script;
 
                             if (requireMethod === constants.TYPE_REQUIRE) {
-                                script = `const ${importName} = require('${relativePath}');`;
+                                script = `const ${importName} = require('${relativePath}')`;
                             } else {
-                                script = `import ${importName} from '${relativePath}';`;
+                                script = `import ${importName} from '${relativePath}'`;
+                            }
+                        
+                            if (config.use_semicolon) {
+                                return `${script};`;
                             }
 
                             return script;


### PR DESCRIPTION
This adds a `bitk_node_require.use_semicolon` option that lets the developer disable semicolons. Would be better if it autodetected this, so if that is preferred let me know.