### PR TITLE
Improve get-position to properly handle block comments and multi-line braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ jspm_packages
 
 
 # End of https://www.gitignore.io/api/node
+
+.vscode
+dump.rdb
+*.vsix

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vs-code-bitkompagniet-require",
   "displayName": "Bitkompagniet Node Require",
   "description": "Require files, dependencies and core modules",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "publisher": "bitkompagniet",
   "engines": {
     "vscode": "^1.0.0"
@@ -13,9 +13,7 @@
   "galleryBanner": {
     "color": "#bdc3c7"
   },
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "activationEvents": [
     "onLanguage:javascript",
     "onCommand:bitk_node_require.require",
@@ -29,34 +27,24 @@
       "properties": {
         "bitk_node_require.include": {
           "type": "array",
-          "default": [
-            "js",
-            "ts",
-            "jsx",
-            "tsx"
-          ],
+          "default": ["js", "ts", "jsx", "tsx"],
           "description": "include files to search for"
         },
         "bitk_node_require.exclude": {
           "type": "array",
-          "default": [
-            "node_modules",
-            "typings",
-            "dist",
-            "bin",
-            "build",
-            "tmp"
-          ],
+          "default": ["node_modules", "typings", "dist", "bin", "build", "tmp"],
           "description": "defines files and folders to exclude"
         },
         "bitk_node_require.search_module_files": {
           "type": "boolean",
           "default": false,
-          "description": "whether we want to search files inside node module directories (performance might be sluggish)"
+          "description":
+            "whether we want to search files inside node module directories (performance might be sluggish)"
         },
         "bitk_node_require.aliases": {
           "type": "object",
-          "description": "A mapping from module name to a different alias (the variable name it is assigned to)",
+          "description":
+            "A mapping from module name to a different alias (the variable name it is assigned to)",
           "default": {
             "backbone": "Backbone",
             "backbone.marionette": "Marionette",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "galleryBanner": {
     "color": "#bdc3c7"
   },
-  "categories": ["Other"],
+  "categories": [
+    "Other"
+  ],
   "activationEvents": [
     "onLanguage:javascript",
     "onCommand:bitk_node_require.require",
@@ -27,24 +29,39 @@
       "properties": {
         "bitk_node_require.include": {
           "type": "array",
-          "default": ["js", "ts", "jsx", "tsx"],
+          "default": [
+            "js",
+            "ts",
+            "jsx",
+            "tsx"
+          ],
           "description": "include files to search for"
+        },
+        "bitk_node_require.use_semicolon": {
+          "type": "boolean",
+          "default": true,
+          "description": "Adds a semicolon at the end of the require statement"
         },
         "bitk_node_require.exclude": {
           "type": "array",
-          "default": ["node_modules", "typings", "dist", "bin", "build", "tmp"],
+          "default": [
+            "node_modules",
+            "typings",
+            "dist",
+            "bin",
+            "build",
+            "tmp"
+          ],
           "description": "defines files and folders to exclude"
         },
         "bitk_node_require.search_module_files": {
           "type": "boolean",
           "default": false,
-          "description":
-            "whether we want to search files inside node module directories (performance might be sluggish)"
+          "description": "whether we want to search files inside node module directories (performance might be sluggish)"
         },
         "bitk_node_require.aliases": {
           "type": "object",
-          "description":
-            "A mapping from module name to a different alias (the variable name it is assigned to)",
+          "description": "A mapping from module name to a different alias (the variable name it is assigned to)",
           "default": {
             "backbone": "Backbone",
             "backbone.marionette": "Marionette",

--- a/src/extension.js
+++ b/src/extension.js
@@ -109,7 +109,9 @@ function activate(context) {
                                 relativePath = relativePath.slice(0, relativePath.length - '/index.js'.length);
                             }
 
-                            importName = caseName(path.basename(relativePath).split('.')[0]);
+                            const baseName = caseName(path.basename(relativePath).split('.')[0]);
+                            const aliasName = commonNames(baseName, config.aliases);
+                            importName = aliasName || baseName;
 
                             if (!isInModules && relativePath.indexOf('../') === -1) {
                                 relativePath = `./${relativePath}`;

--- a/src/get-position.js
+++ b/src/get-position.js
@@ -11,6 +11,7 @@ function isLocalRequire(line) {
 
 module.exports = function(codeBlock, placeWithExternals) {
     let candidate = 0;
+    let requiresStarted = false;
     for (let i = 0; i < codeBlock.length; i += 1) {
         const line = codeBlock[i];
         if (isRequire(line) && (
@@ -18,9 +19,12 @@ module.exports = function(codeBlock, placeWithExternals) {
             (placeWithExternals && !isLocalRequire(line))
            )
         ) {
+            requiresStarted = true;
             candidate = i + 1;
         } else if (!isCommentOrEmpty(line)) {
             break;
+        } else if (isCommentOrEmpty(line) && !requiresStarted) {
+            candidate = i + 1;
         }
     }
     return candidate;

--- a/src/get-position.js
+++ b/src/get-position.js
@@ -11,9 +11,21 @@ function isLocalRequire(line) {
 
 module.exports = function(codeBlock, placeWithExternals) {
     let candidate = 0;
+    let inBlockComment = false;
+    let inBracket = false;
     for (let i = 0; i < codeBlock.length; i += 1) {
         const line = codeBlock[i];
-        if (isRequire(line) && (
+        if (!inBlockComment && !inBracket) {
+            if (line.match(/\/*/)) inBlockComment = true;
+            if (line.match(/{/)) inBracket = true;
+        } else if (inBlockComment) {
+            if (line.match(/\/\*\//)) inBlockComment = false;
+        } else if (inBracket) {
+            if (line.match(/}/)) inBracket = false;
+        }
+        if (inBracket || inBlockComment) {
+            candidate = i + 1;
+        } else if (isRequire(line) && (
             !placeWithExternals ||
             (placeWithExternals && !isLocalRequire(line))
            )

--- a/src/get-position.js
+++ b/src/get-position.js
@@ -11,21 +11,9 @@ function isLocalRequire(line) {
 
 module.exports = function(codeBlock, placeWithExternals) {
     let candidate = 0;
-    let inBlockComment = false;
-    let inBracket = false;
     for (let i = 0; i < codeBlock.length; i += 1) {
         const line = codeBlock[i];
-        if (!inBlockComment && !inBracket) {
-            if (line.match(/\/*/)) inBlockComment = true;
-            if (line.match(/{/)) inBracket = true;
-        } else if (inBlockComment) {
-            if (line.match(/\/\*\//)) inBlockComment = false;
-        } else if (inBracket) {
-            if (line.match(/}/)) inBracket = false;
-        }
-        if (inBracket || inBlockComment) {
-            candidate = i + 1;
-        } else if (isRequire(line) && (
+        if (isRequire(line) && (
             !placeWithExternals ||
             (placeWithExternals && !isLocalRequire(line))
            )

--- a/src/get-position.js
+++ b/src/get-position.js
@@ -2,36 +2,72 @@ const _ = require('lodash');
 const isRequire = require('./is-require');
 
 function isCommentOrEmpty(line) {
-    return _.isEmpty(line) || line.match(/^\s*\/\//) || line.match(/^\s*["']use strict["']/);
+    return _.isEmpty(line) ||
+    line.match(/^\s*\/\//) ||
+    line.match(/^\s*["']use strict["']/);
 }
 
 function isLocalRequire(line) {
     return line.match(/require\([\s]?['|"][.|/]/) || line.match(/^import.*from\s['|"][.|/]/);
 }
 
+function isInBracketOrComment(line, context) {
+    let { inBlockComment, inBracket } = context;
+    if (!inBlockComment && !inBracket) {
+        if (line.match(/\/\*/)) {
+            inBlockComment = true;
+        }
+        if (line.match(/import.*{/)) {
+            inBracket = true;
+        }
+    }
+    if (inBlockComment && line.match(/\*\//)) {
+        inBlockComment = false;
+    }
+    if (inBracket && line.match(/}/)) {
+        inBracket = false;
+    }
+    return {
+        inBlockComment,
+        inBracket,
+    };
+}
+
 module.exports = function(codeBlock, placeWithExternals) {
     let candidate = 0;
-    let inBlockComment = false;
-    let inBracket = false;
+    let context = {
+        inBlockComment: false,
+        inBracket: false,
+    };
+    let requiresStarted = false;
     for (let i = 0; i < codeBlock.length; i += 1) {
         const line = codeBlock[i];
-        if (!inBlockComment && !inBracket) {
-            if (line.match(/\/*/)) inBlockComment = true;
-            if (line.match(/{/)) inBracket = true;
-        } else if (inBlockComment) {
-            if (line.match(/\/\*\//)) inBlockComment = false;
-        } else if (inBracket) {
-            if (line.match(/}/)) inBracket = false;
-        }
-        if (inBracket || inBlockComment) {
-            candidate = i + 1;
+        context = isInBracketOrComment(line, context);
+
+        // If we're in a comment or bracket, the candidate is
+        // 2 positions out (to account for the closing tag)
+        if (context.inBlockComment || context.inBracket) {
+            candidate = i + 2;
+
+        // If the current line is an import bump the candidate up
+        // if we're not in the appropriate section for the new import.
+        // Also, mark that the require section has started
         } else if (isRequire(line) && (
             !placeWithExternals ||
             (placeWithExternals && !isLocalRequire(line))
            )
         ) {
+            requiresStarted = true;
             candidate = i + 1;
-        } else if (!isCommentOrEmpty(line)) {
+
+        // If the requires section hasn't started yet and we're at a
+        // comment, bump candidate up
+        } else if (isCommentOrEmpty(line) && !requiresStarted) {
+            candidate = i + 1;
+
+        // If the requires section has started and we're not on a
+        // require anymore, we're done
+        } else if (!isCommentOrEmpty(line) && requiresStarted) {
             break;
         }
     }


### PR DESCRIPTION
Here's a pull request that should resolve #14 as well as #10. It also detects flow type `import type` definitions, and places other imports above those (so the order is external imports -> local imports -> type imports)

To do this it adds a few methods to `get-position`: 

`isComment`, `isTypeDefinition` and `isInBracketOrComment`.

There's some added complexity in the main `get-position` function to track the context that the current line is part of (if it is within a block comment or a bracket), plus some additional logic to handle those conditions.

I think I've handled most of the edge cases but please test and let me know if it needs any further improvements!